### PR TITLE
Updating numpy version to support Python 3.12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
+setuptools; python_version >= "3.12"
 certifi==2021.10.8
-numpy==1.25.1
+numpy==1.26.3
 pandas==1.4.2
 python-dateutil==2.8.2
 pytz==2022.1

--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(
     ),
     install_requires=[
         "certifi==2021.10.8",
-        "numpy==1.25.1",
+        "numpy==1.26.3",
         "pandas==1.4.2",
         "python-dateutil==2.8.2",
         "pytz==2022.1",


### PR DESCRIPTION
Hi @ajunius-ANSSI et al.

This PR updates the version of the `numpy` package so that it can be run in Python 3.12!

Kevin 🇨🇦